### PR TITLE
Add adjustable speed profiles for SpaceMouse axes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Firmware/Hackman3D_Orbit_Controller/Hackman3D_Orbit_Controller.ino
+++ b/Firmware/Hackman3D_Orbit_Controller/Hackman3D_Orbit_Controller.ino
@@ -1,4 +1,5 @@
 #include "HID.h"
+#include <math.h>
 
 // ============================================================================
 // Hackman3D DIY SpaceMouse Firmware
@@ -48,6 +49,35 @@ const float GAIN_RX = 1.8;
 const float GAIN_RY = 1.8;
 const float GAIN_RZ = 2.0;
 
+// EN: Global maximum speed scale. 0.70 means 30% slower than the base firmware.
+// FR: Échelle globale de vitesse maximale. 0.70 signifie 30 % plus lent.
+const float MAX_SPEED_SCALE = 0.70;
+
+// EN: Response curve. 1.0 is linear; higher values make small movements slower.
+// FR: Courbe de réponse. 1.0 est linéaire ; plus haut adoucit les petits mouvements.
+const float RESPONSE_CURVE = 1.6;
+
+// EN: Speed profiles. Default mode 1 keeps the values above.
+// FR: Profils de vitesse. Le mode par défaut 1 garde les valeurs ci-dessus.
+const int SPEED_MODE_COUNT = 3;
+const int DEFAULT_SPEED_MODE = 1;
+const float SPEED_MODE_SCALE[SPEED_MODE_COUNT] = {
+  0.50,
+  MAX_SPEED_SCALE,
+  1.00
+};
+const float SPEED_MODE_RESPONSE_CURVE[SPEED_MODE_COUNT] = {
+  1.9,
+  RESPONSE_CURVE,
+  1.3
+};
+
+// EN: Serial debug output. Keep disabled during normal HID use.
+// FR: Sortie debug série. Garder désactivé pendant l’utilisation HID normale.
+const bool DEBUG_SERIAL = false;
+const unsigned long DEBUG_SERIAL_BAUD = 115200;
+const unsigned long DEBUG_SERIAL_INTERVAL_MS = 100;
+
 // EN: Lower value gives rotation more priority over translation.
 // FR: Plus la valeur est basse, plus la rotation est prioritaire.
 const float ROTATION_PRIORITY = 0.65;
@@ -85,6 +115,23 @@ const int pins[8] = {
 const int buttonPins[3] = { 2, 3, 7 };
 const int BUTTON_COUNT = 3;
 
+// EN: Button indexes used to switch speed mode. Default = all three buttons.
+// FR: Index des boutons utilisés pour changer de mode. Défaut = trois boutons.
+const int MODE_SWITCH_BUTTONS[BUTTON_COUNT] = { 0, 1, 2 };
+const int MODE_SWITCH_BUTTON_COUNT = 3;
+
+// EN: If true, the mode-switch button combo is not sent as normal HID buttons.
+// FR: Si vrai, la combinaison de changement de mode n’est pas envoyée en HID.
+const bool MODE_SWITCH_SUPPRESS_BUTTONS = true;
+
+// EN: Time to wait for the full combo before sending individual combo buttons.
+// FR: Temps d’attente de la combinaison avant d’envoyer les boutons séparés.
+const unsigned long MODE_SWITCH_CHORD_WINDOW_MS = 250;
+
+// EN: Minimum time between two speed mode changes.
+// FR: Temps minimum entre deux changements de mode de vitesse.
+const unsigned long MODE_SWITCH_DEBOUNCE_MS = 500;
+
 
 // ============================================================================
 // GLOBAL VARIABLES / VARIABLES GLOBALES
@@ -102,6 +149,18 @@ int16_t smoothTZ = 0;
 int16_t smoothRX = 0;
 int16_t smoothRY = 0;
 int16_t smoothRZ = 0;
+
+// EN: Current speed profile index.
+// FR: Index du profil de vitesse actuel.
+int currentSpeedMode = DEFAULT_SPEED_MODE;
+
+bool modeSwitchComboWasPressed = false;
+bool modeSwitchChordActive = false;
+bool modeSwitchChordComboTriggered = false;
+bool modeSwitchButtonsForwarded = false;
+uint32_t modeSwitchPendingButtons = 0;
+unsigned long modeSwitchChordStartedAt = 0;
+unsigned long lastModeSwitchAt = 0;
 
 
 // ============================================================================
@@ -287,7 +346,19 @@ int countNegative4(int a, int b, int c, int d, int threshold) {
 // ============================================================================
 
 int16_t smoothValue(int16_t current, int16_t target) {
-  return current + (target - current) / SMOOTH_DIVISOR;
+  int16_t delta = target - current;
+
+  if (delta == 0) {
+    return current;
+  }
+
+  int16_t step = delta / SMOOTH_DIVISOR;
+
+  if (step == 0) {
+    step = (delta > 0) ? 1 : -1;
+  }
+
+  return current + step;
 }
 
 
@@ -299,6 +370,83 @@ int16_t smoothValue(int16_t current, int16_t target) {
 
 int16_t applyGain(int16_t value, float gain) {
   return (int16_t)(value * gain);
+}
+
+
+// ============================================================================
+// applyResponseCurve()
+// EN: Scales maximum speed and makes small movements easier to control.
+// FR: Réduit la vitesse maximale et rend les petits mouvements plus contrôlables.
+// ============================================================================
+
+int16_t applyResponseCurve(int16_t value, float inputMax,
+                           float speedScale, float responseCurve) {
+  if (value == 0) {
+    return 0;
+  }
+
+  float magnitude = abs(value);
+  float maxMagnitude = inputMax;
+
+  if (maxMagnitude < DEADZONE_OUTPUT + 1.0) {
+    maxMagnitude = DEADZONE_OUTPUT + 1.0;
+  }
+
+  if (magnitude < DEADZONE_OUTPUT) {
+    return 0;
+  }
+
+  if (magnitude > maxMagnitude) {
+    magnitude = maxMagnitude;
+  }
+
+  float normalized = (magnitude - DEADZONE_OUTPUT) / (maxMagnitude - DEADZONE_OUTPUT);
+  float maxOutputMagnitude = maxMagnitude * speedScale;
+
+  if (maxOutputMagnitude < DEADZONE_OUTPUT) {
+    maxOutputMagnitude = DEADZONE_OUTPUT;
+  }
+
+  float curved = DEADZONE_OUTPUT +
+                  pow(normalized, responseCurve) *
+                  (maxOutputMagnitude - DEADZONE_OUTPUT);
+
+  if (value < 0) {
+    curved = -curved;
+  }
+
+  return (int16_t)curved;
+}
+
+
+// ============================================================================
+// resetSmoothing()
+// EN: Clears smoothed axis memory after mode changes.
+// FR: Réinitialise le lissage après un changement de mode.
+// ============================================================================
+
+void resetSmoothing() {
+  smoothTX = 0;
+  smoothTY = 0;
+  smoothTZ = 0;
+
+  smoothRX = 0;
+  smoothRY = 0;
+  smoothRZ = 0;
+}
+
+
+// ============================================================================
+// resetModeSwitchChord()
+// EN: Clears temporary state used while detecting a speed-mode button chord.
+// FR: Réinitialise l’état temporaire de détection de la combinaison de boutons.
+// ============================================================================
+
+void resetModeSwitchChord() {
+  modeSwitchChordActive = false;
+  modeSwitchChordComboTriggered = false;
+  modeSwitchButtonsForwarded = false;
+  modeSwitchPendingButtons = 0;
 }
 
 
@@ -367,6 +515,165 @@ void sendCommand(int16_t rx, int16_t ry, int16_t rz,
 
 
 // ============================================================================
+// readButtonMask()
+// EN: Reads physical buttons into a bit mask.
+// FR: Lit les boutons physiques dans un masque de bits.
+// ============================================================================
+
+uint32_t readButtonMask() {
+  uint32_t buttons = 0;
+
+  for (int i = 0; i < BUTTON_COUNT; i++) {
+    if (digitalRead(buttonPins[i]) == LOW) {
+      buttons |= (1UL << i);
+    }
+  }
+
+  return buttons;
+}
+
+
+// ============================================================================
+// getModeSwitchButtonMask()
+// EN: Builds a bit mask from the configured mode-switch buttons.
+// FR: Crée un masque à partir des boutons configurés pour changer de mode.
+// ============================================================================
+
+uint32_t getModeSwitchButtonMask() {
+  if (MODE_SWITCH_BUTTON_COUNT <= 0 || MODE_SWITCH_BUTTON_COUNT > BUTTON_COUNT) {
+    return 0;
+  }
+
+  uint32_t comboMask = 0;
+
+  for (int i = 0; i < MODE_SWITCH_BUTTON_COUNT; i++) {
+    int buttonIndex = MODE_SWITCH_BUTTONS[i];
+
+    if (buttonIndex < 0 || buttonIndex >= BUTTON_COUNT) {
+      return 0;
+    }
+
+    comboMask |= (1UL << buttonIndex);
+  }
+
+  return comboMask;
+}
+
+
+// ============================================================================
+// isModeSwitchComboPressed()
+// EN: Checks if the configured speed mode button combo is pressed.
+// FR: Vérifie si la combinaison de changement de mode est appuyée.
+// ============================================================================
+
+bool isModeSwitchComboPressed(uint32_t buttonMask) {
+  uint32_t comboMask = getModeSwitchButtonMask();
+
+  if (comboMask == 0) {
+    return false;
+  }
+
+  return (buttonMask & comboMask) == comboMask;
+}
+
+
+// ============================================================================
+// updateSpeedMode()
+// EN: Cycles through slow / normal / fast speed profiles.
+// FR: Change de profil lent / normal / rapide.
+// ============================================================================
+
+void updateSpeedMode(bool comboPressed) {
+  unsigned long now = millis();
+
+  if (comboPressed &&
+      !modeSwitchComboWasPressed &&
+      now - lastModeSwitchAt >= MODE_SWITCH_DEBOUNCE_MS) {
+    currentSpeedMode++;
+
+    if (currentSpeedMode >= SPEED_MODE_COUNT) {
+      currentSpeedMode = 0;
+    }
+
+    lastModeSwitchAt = now;
+    resetSmoothing();
+  }
+
+  modeSwitchComboWasPressed = comboPressed;
+}
+
+
+// ============================================================================
+// filterModeSwitchButtons()
+// EN: Suppresses shortcut buttons while a speed-mode chord is being detected.
+// FR: Bloque les boutons du raccourci pendant la détection de la combinaison.
+// ============================================================================
+
+uint32_t filterModeSwitchButtons(uint32_t buttonMask, bool comboPressed, bool &comboAccepted) {
+  comboAccepted = false;
+
+  if (!MODE_SWITCH_SUPPRESS_BUTTONS) {
+    comboAccepted = comboPressed;
+    return buttonMask;
+  }
+
+  uint32_t switchMask = getModeSwitchButtonMask();
+
+  if (switchMask == 0) {
+    return buttonMask;
+  }
+
+  unsigned long now = millis();
+  uint32_t nonSwitchButtons = buttonMask & ~switchMask;
+  uint32_t activeSwitchButtons = buttonMask & switchMask;
+
+  if (activeSwitchButtons == 0) {
+    modeSwitchChordActive = false;
+
+    if (!modeSwitchChordComboTriggered &&
+        !modeSwitchButtonsForwarded &&
+        modeSwitchPendingButtons != 0) {
+      uint32_t releasedButtons = modeSwitchPendingButtons;
+      resetModeSwitchChord();
+
+      return nonSwitchButtons | releasedButtons;
+    }
+
+    resetModeSwitchChord();
+    return nonSwitchButtons;
+  }
+
+  if (!modeSwitchChordActive) {
+    modeSwitchChordActive = true;
+    modeSwitchChordComboTriggered = false;
+    modeSwitchButtonsForwarded = false;
+    modeSwitchPendingButtons = activeSwitchButtons;
+    modeSwitchChordStartedAt = now;
+  } else {
+    modeSwitchPendingButtons |= activeSwitchButtons;
+  }
+
+  if (comboPressed && now - modeSwitchChordStartedAt <= MODE_SWITCH_CHORD_WINDOW_MS) {
+    modeSwitchChordComboTriggered = true;
+    comboAccepted = true;
+    return nonSwitchButtons;
+  }
+
+  if (modeSwitchChordComboTriggered) {
+    comboAccepted = true;
+    return nonSwitchButtons;
+  }
+
+  if (now - modeSwitchChordStartedAt < MODE_SWITCH_CHORD_WINDOW_MS) {
+    return nonSwitchButtons;
+  }
+
+  modeSwitchButtonsForwarded = true;
+  return buttonMask;
+}
+
+
+// ============================================================================
 // sendButtons()
 // EN:
 // Reads the physical buttons and sends them as HID button states.
@@ -375,16 +682,68 @@ void sendCommand(int16_t rx, int16_t ry, int16_t rz,
 // Lit les boutons physiques et les envoie comme états de boutons HID.
 // ============================================================================
 
-void sendButtons() {
+void sendButtons(uint32_t buttonMask) {
   uint8_t buttons[4] = { 0, 0, 0, 0 };
 
   for (int i = 0; i < BUTTON_COUNT; i++) {
-    if (digitalRead(buttonPins[i]) == LOW) {
+    if ((buttonMask & (1UL << i)) != 0) {
       buttons[i / 8] |= (1 << (i % 8));
     }
   }
 
   HID().SendReport(3, buttons, 4);
+}
+
+
+// ============================================================================
+// debugPrintState()
+// EN: Optional Serial Plotter friendly debug output.
+// FR: Sortie debug optionnelle compatible Serial Plotter.
+// ============================================================================
+
+void debugPrintState(const int* values,
+                     int16_t tx, int16_t ty, int16_t tz,
+                     int16_t rx, int16_t ry, int16_t rz,
+                     uint32_t buttonMask) {
+  if (!DEBUG_SERIAL) {
+    return;
+  }
+
+  static unsigned long lastDebugAt = 0;
+  unsigned long now = millis();
+
+  if (now - lastDebugAt < DEBUG_SERIAL_INTERVAL_MS) {
+    return;
+  }
+
+  lastDebugAt = now;
+
+  Serial.print("mode:");
+  Serial.print(currentSpeedMode);
+
+  Serial.print(" buttons:");
+  Serial.print(buttonMask);
+
+  for (int i = 0; i < 8; i++) {
+    Serial.print(" v");
+    Serial.print(i);
+    Serial.print(":");
+    Serial.print(values[i]);
+  }
+
+  Serial.print(" tx:");
+  Serial.print(tx);
+  Serial.print(" ty:");
+  Serial.print(ty);
+  Serial.print(" tz:");
+  Serial.print(tz);
+
+  Serial.print(" rx:");
+  Serial.print(rx);
+  Serial.print(" ry:");
+  Serial.print(ry);
+  Serial.print(" rz:");
+  Serial.println(rz);
 }
 
 
@@ -400,6 +759,10 @@ void sendButtons() {
 void setup() {
   static HIDSubDescriptor node(hidReportDescriptor, sizeof(hidReportDescriptor));
   HID().AppendDescriptor(&node);
+
+  if (DEBUG_SERIAL) {
+    Serial.begin(DEBUG_SERIAL_BAUD);
+  }
 
   for (int i = 0; i < BUTTON_COUNT; i++) {
     pinMode(buttonPins[i], INPUT_PULLUP);
@@ -441,6 +804,14 @@ void setup() {
 void loop() {
   int raw[8];
   int v[8];
+  uint32_t buttonMask = readButtonMask();
+  bool modeSwitchComboPressed = isModeSwitchComboPressed(buttonMask);
+  bool modeSwitchComboAccepted = false;
+  uint32_t hidButtonMask = filterModeSwitchButtons(buttonMask,
+                                                  modeSwitchComboPressed,
+                                                  modeSwitchComboAccepted);
+
+  updateSpeedMode(modeSwitchComboAccepted);
 
   // EN: Read raw joystick values.
   // FR: Lecture des valeurs brutes des joysticks.
@@ -572,6 +943,21 @@ void loop() {
   keepOnlyDominantAxis(transX, transY, transZ, rotX, rotY, rotZ);
 
   // --------------------------------------------------------------------------
+  // RESPONSE CURVE / COURBE DE RÉPONSE
+  // --------------------------------------------------------------------------
+
+  float speedScale = SPEED_MODE_SCALE[currentSpeedMode];
+  float responseCurve = SPEED_MODE_RESPONSE_CURVE[currentSpeedMode];
+
+  transX = applyResponseCurve(transX, 1024.0 * GAIN_TX, speedScale, responseCurve);
+  transY = applyResponseCurve(transY, 1024.0 * GAIN_TY, speedScale, responseCurve);
+  transZ = applyResponseCurve(transZ, 2048.0 * GAIN_TZ, speedScale, responseCurve);
+
+  rotX = applyResponseCurve(rotX, 1024.0 * GAIN_RX, speedScale, responseCurve);
+  rotY = applyResponseCurve(rotY, 1024.0 * GAIN_RY, speedScale, responseCurve);
+  rotZ = applyResponseCurve(rotZ, 1024.0 * GAIN_RZ, speedScale, responseCurve);
+
+  // --------------------------------------------------------------------------
   // OUTPUT DEADZONE / ZONE MORTE DE SORTIE
   // --------------------------------------------------------------------------
 
@@ -604,13 +990,15 @@ void loop() {
   // FINAL DEADZONE / ZONE MORTE FINALE
   // --------------------------------------------------------------------------
 
-  if (abs(smoothTX) < DEADZONE_OUTPUT) smoothTX = 0;
-  if (abs(smoothTY) < DEADZONE_OUTPUT) smoothTY = 0;
-  if (abs(smoothTZ) < DEADZONE_OUTPUT) smoothTZ = 0;
+  int16_t outputTX = smoothTX;
+  int16_t outputTY = smoothTY;
+  int16_t outputTZ = smoothTZ;
 
-  if (abs(smoothRX) < DEADZONE_OUTPUT) smoothRX = 0;
-  if (abs(smoothRY) < DEADZONE_OUTPUT) smoothRY = 0;
-  if (abs(smoothRZ) < DEADZONE_OUTPUT) smoothRZ = 0;
+  int16_t outputRX = smoothRX;
+  int16_t outputRY = smoothRY;
+  int16_t outputRZ = smoothRZ;
+
+  applyOutputDeadzone(outputTX, outputTY, outputTZ, outputRX, outputRY, outputRZ);
 
   // --------------------------------------------------------------------------
   // SEND HID REPORTS / ENVOI DES RAPPORTS HID
@@ -623,13 +1011,14 @@ void loop() {
   // L’ordre des axes est ajusté ici pour correspondre au comportement du driver
   // 3Dconnexion.
   sendCommand(
-    smoothRX,
-    smoothRZ,
-    smoothRY,
-    smoothTX,
-    smoothTZ,
-    smoothTY
+    outputRX,
+    outputRZ,
+    outputRY,
+    outputTX,
+    outputTZ,
+    outputTY
   );
 
-  sendButtons();
+  sendButtons(hidButtonMask);
+  debugPrintState(v, outputTX, outputTY, outputTZ, outputRX, outputRY, outputRZ, buttonMask);
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains everything needed to build your own controller, includi
 * 6 Degrees of Freedom (6-DOF)
 * Hall Effect joystick technology
 * Arduino Pro Micro based firmware
+* Adjustable speed profiles and response curve
 * USB-C connectivity
 * Fully 3D printable design
 * Optional mechanical shortcut buttons

--- a/TUNING_GUIDE.md
+++ b/TUNING_GUIDE.md
@@ -1,6 +1,6 @@
 # Hackman3D Orbit Controller - Tuning Guide
 
-This guide explains how to adjust the **dead zones**, **sensitivity**, and **reactivity** of the Hackman3D Orbit Controller if your controller feels too sensitive, too slow, unstable, or if it produces unwanted movements.
+This guide explains how to adjust the **dead zones**, **speed**, **sensitivity**, and **reactivity** of the Hackman3D Orbit Controller if your controller feels too sensitive, too slow, unstable, or if it produces unwanted movements.
 
 All settings are located near the top of the firmware file:
 
@@ -20,7 +20,36 @@ const float GAIN_RX = 1.8;
 const float GAIN_RY = 1.8;
 const float GAIN_RZ = 2.0;
 
+const float MAX_SPEED_SCALE = 0.70;
+const float RESPONSE_CURVE = 1.6;
+
+const int SPEED_MODE_COUNT = 3;
+const int DEFAULT_SPEED_MODE = 1;
+const float SPEED_MODE_SCALE[SPEED_MODE_COUNT] = {
+  0.50,
+  MAX_SPEED_SCALE,
+  1.00
+};
+const float SPEED_MODE_RESPONSE_CURVE[SPEED_MODE_COUNT] = {
+  1.9,
+  RESPONSE_CURVE,
+  1.3
+};
+
+const bool DEBUG_SERIAL = false;
+const unsigned long DEBUG_SERIAL_BAUD = 115200;
+const unsigned long DEBUG_SERIAL_INTERVAL_MS = 100;
+
 const float ROTATION_PRIORITY = 0.65;
+
+// PIN CONFIGURATION / CONFIGURATION DES PINS
+const int buttonPins[3] = { 2, 3, 7 };
+const int BUTTON_COUNT = 3;
+const int MODE_SWITCH_BUTTONS[BUTTON_COUNT] = { 0, 1, 2 };
+const int MODE_SWITCH_BUTTON_COUNT = 3;
+const bool MODE_SWITCH_SUPPRESS_BUTTONS = true;
+const unsigned long MODE_SWITCH_CHORD_WINDOW_MS = 250;
+const unsigned long MODE_SWITCH_DEBOUNCE_MS = 500;
 ```
 
 After changing a value, upload the firmware again with Arduino IDE and test the controller in your 3D/CAD software.
@@ -182,7 +211,232 @@ const int SMOOTH_DIVISOR = 7;
 
 ---
 
-## 5. Translation sensitivity
+## 5. Speed scale / response curve
+
+```cpp
+const float MAX_SPEED_SCALE = 0.70;
+const float RESPONSE_CURVE = 1.6;
+```
+
+These values control the global speed and the response curve of the controller.
+
+`MAX_SPEED_SCALE` limits the maximum speed of all axes.
+`RESPONSE_CURVE` changes how progressively the controller reacts near the center.
+
+A lower `MAX_SPEED_SCALE` makes the controller slower.
+A higher `RESPONSE_CURVE` makes small movements softer and more precise.
+
+### Decrease the speed scale if:
+
+- all axes feel too fast;
+- the camera moves too quickly;
+- maximum speed is too high.
+
+### Increase the speed scale if:
+
+- all axes feel too slow;
+- maximum speed is too low;
+- you need to push too far to reach full speed.
+
+### Increase the response curve if:
+
+- small movements are too sensitive;
+- the controller feels too nervous near the center;
+- you want more gradual acceleration.
+
+### Decrease the response curve if:
+
+- movement starts too slowly;
+- the controller feels too soft or delayed.
+
+### Recommended ranges
+
+```cpp
+MAX_SPEED_SCALE = 0.50 to 1.00
+RESPONSE_CURVE  = 1.0 to 2.2
+```
+
+### Examples
+
+Default slower profile:
+
+```cpp
+const float MAX_SPEED_SCALE = 0.70;
+const float RESPONSE_CURVE = 1.6;
+```
+
+Lower maximum speed:
+
+```cpp
+const float MAX_SPEED_SCALE = 0.50;
+const float RESPONSE_CURVE = 1.6;
+```
+
+Softer start near the center:
+
+```cpp
+const float MAX_SPEED_SCALE = 0.70;
+const float RESPONSE_CURVE = 1.9;
+```
+
+More direct response:
+
+```cpp
+const float MAX_SPEED_SCALE = 0.70;
+const float RESPONSE_CURVE = 1.0;
+```
+
+Adjust these values before changing individual axis gains.
+
+---
+
+## 6. Speed modes / button shortcut
+
+```cpp
+const int SPEED_MODE_COUNT = 3;
+const int DEFAULT_SPEED_MODE = 1;
+
+const float SPEED_MODE_SCALE[SPEED_MODE_COUNT] = {
+  0.50,
+  MAX_SPEED_SCALE,
+  1.00
+};
+
+const float SPEED_MODE_RESPONSE_CURVE[SPEED_MODE_COUNT] = {
+  1.9,
+  RESPONSE_CURVE,
+  1.3
+};
+```
+
+Speed modes let the controller switch between slow, normal, and fast profiles without changing the firmware every time.
+
+Default mode `1` is the normal profile.
+By default, pressing all three buttons at the same time changes the speed mode.
+
+The default button shortcut cycles through:
+
+1. slow;
+2. normal;
+3. fast.
+
+### Default profiles
+
+```cpp
+slow   = 50% speed, softer start
+normal = 70% speed, balanced start
+fast   = 100% speed, more direct start
+```
+
+### Change the startup mode if:
+
+- you always want the controller to start slower;
+- you always want the controller to start faster;
+- you do not want to use the button shortcut during normal use.
+
+### Example
+
+Start in slow mode:
+
+```cpp
+const int DEFAULT_SPEED_MODE = 0;
+```
+
+Start in fast mode:
+
+```cpp
+const int DEFAULT_SPEED_MODE = 2;
+```
+
+### Button shortcut
+
+```cpp
+const int MODE_SWITCH_BUTTONS[BUTTON_COUNT] = { 0, 1, 2 };
+const int MODE_SWITCH_BUTTON_COUNT = 3;
+const bool MODE_SWITCH_SUPPRESS_BUTTONS = true;
+const unsigned long MODE_SWITCH_CHORD_WINDOW_MS = 250;
+const unsigned long MODE_SWITCH_DEBOUNCE_MS = 500;
+```
+
+The default shortcut uses all three buttons at the same time.
+
+Button indexes start from `0`, so the three default buttons are:
+
+```cpp
+0, 1, 2
+```
+
+`MODE_SWITCH_BUTTON_COUNT` controls how many button indexes are used.
+
+### Examples
+
+Use only buttons 0 and 1 to switch speed mode:
+
+```cpp
+const int MODE_SWITCH_BUTTONS[BUTTON_COUNT] = { 0, 1, 2 };
+const int MODE_SWITCH_BUTTON_COUNT = 2;
+```
+
+Disable the speed mode shortcut:
+
+```cpp
+const int MODE_SWITCH_BUTTON_COUNT = 0;
+```
+
+If `MODE_SWITCH_SUPPRESS_BUTTONS` is `true`, the shortcut is not sent to the computer as normal button presses.
+
+`MODE_SWITCH_CHORD_WINDOW_MS` is the time allowed to complete the speed-mode button combo.
+This prevents CAD software from receiving one button while you are pressing the full combo.
+
+A quick single-button tap is sent as soon as the button is released.
+A held single button is sent after the chord window expires.
+A full combo switches speed mode only if all shortcut buttons are pressed within the chord window.
+
+Keep `MODE_SWITCH_CHORD_WINDOW_MS` around `150` to `400`.
+Lower it if held single buttons feel delayed.
+Increase it if your software still detects one button while switching speed mode.
+
+Keep `MODE_SWITCH_DEBOUNCE_MS` around `300` to `700` unless one press changes mode more than once.
+
+---
+
+## 7. Serial debug output
+
+```cpp
+const bool DEBUG_SERIAL = false;
+const unsigned long DEBUG_SERIAL_BAUD = 115200;
+const unsigned long DEBUG_SERIAL_INTERVAL_MS = 100;
+```
+
+Serial debug output prints the current speed mode, button mask, joystick values, and final HID output values.
+
+Keep this disabled during normal use.
+Enable it only when you need to check raw joystick movement, button states, or output values.
+
+### Enable debug output
+
+```cpp
+const bool DEBUG_SERIAL = true;
+```
+
+Then open the Arduino Serial Monitor or Serial Plotter at:
+
+```cpp
+115200 baud
+```
+
+### Increase the interval if:
+
+- the Serial Monitor prints too much data;
+- the controller feels slower while debugging.
+
+### Decrease the interval if:
+
+- you need faster feedback while testing joystick movement.
+
+---
+
+## 8. Translation sensitivity
 
 ```cpp
 const float GAIN_TX = 1.3;
@@ -230,7 +484,7 @@ const float GAIN_TX = 1.6;
 
 ---
 
-## 6. Rotation sensitivity
+## 9. Rotation sensitivity
 
 ```cpp
 const float GAIN_RX = 1.8;
@@ -279,7 +533,7 @@ const float GAIN_RY = 2.1;
 
 ---
 
-## 7. Rotation priority
+## 10. Rotation priority
 
 ```cpp
 const float ROTATION_PRIORITY = 0.65;
@@ -323,7 +577,7 @@ const float ROTATION_PRIORITY = 0.85;
 
 ---
 
-## 8. Center calibration samples
+## 11. Center calibration samples
 
 ```cpp
 const int CENTER_SAMPLES = 100;
@@ -359,7 +613,7 @@ const int CENTER_SAMPLES = 150;
 
 ---
 
-## 9. Common problems and suggested fixes
+## 12. Common problems and suggested fixes
 
 ### The controller moves by itself
 
@@ -379,6 +633,8 @@ Also make sure you do not touch the knob during USB connection.
 Try:
 
 ```cpp
+const float MAX_SPEED_SCALE = 0.85;
+const float RESPONSE_CURVE = 1.3;
 const int SMOOTH_DIVISOR = 3;
 ```
 
@@ -391,11 +647,87 @@ You can also slightly increase the gain values.
 Try:
 
 ```cpp
+const float MAX_SPEED_SCALE = 0.60;
+const float RESPONSE_CURVE = 1.8;
 const int SMOOTH_DIVISOR = 6;
 const int DEADZONE_INPUT = 50;
 ```
 
 You can also lower the gain of the axis that feels too strong.
+
+---
+
+### The maximum speed is too high
+
+Try:
+
+```cpp
+const float MAX_SPEED_SCALE = 0.60;
+```
+
+Use a lower value for a slower controller.
+
+---
+
+### Small movements are too fast
+
+Try:
+
+```cpp
+const float RESPONSE_CURVE = 1.8;
+```
+
+Use a higher value for more gradual acceleration from the center.
+
+---
+
+### A CAD app opens a menu while switching speed mode
+
+Try:
+
+```cpp
+const unsigned long MODE_SWITCH_CHORD_WINDOW_MS = 350;
+```
+
+Use a higher value if the software still receives one of the shortcut buttons before the full combo is detected.
+
+---
+
+### Single shortcut buttons feel delayed
+
+Try:
+
+```cpp
+const unsigned long MODE_SWITCH_CHORD_WINDOW_MS = 150;
+```
+
+Quick taps are sent when the button is released.
+Lower this value if held single-button shortcuts feel delayed.
+
+---
+
+### The speed mode changes more than once
+
+Try:
+
+```cpp
+const unsigned long MODE_SWITCH_DEBOUNCE_MS = 700;
+```
+
+Use a higher value if one shortcut press cycles through more than one speed mode.
+
+---
+
+### You need to check joystick or button values
+
+Try:
+
+```cpp
+const bool DEBUG_SERIAL = true;
+```
+
+Open the Arduino Serial Monitor or Serial Plotter at `115200 baud`.
+Set `DEBUG_SERIAL` back to `false` for normal use.
 
 ---
 
@@ -450,7 +782,7 @@ const float GAIN_RZ = 1.6;
 
 ---
 
-## 10. Recommended tuning method
+## 13. Recommended tuning method
 
 Change only one setting at a time.
 
@@ -459,8 +791,11 @@ Recommended order:
 1. Start with `DEADZONE_INPUT`.
 2. Adjust `DEADZONE_OUTPUT`.
 3. Adjust `SMOOTH_DIVISOR`.
-4. Adjust translation and rotation gains.
-5. Adjust `ROTATION_PRIORITY` only if rotation and translation are mixed.
+4. Adjust `MAX_SPEED_SCALE`.
+5. Adjust `RESPONSE_CURVE`.
+6. Adjust `SPEED_MODE_SCALE` and `SPEED_MODE_RESPONSE_CURVE` if you use speed modes.
+7. Adjust translation and rotation gains only if one axis needs correction.
+8. Adjust `ROTATION_PRIORITY` only if rotation and translation are mixed.
 
 After each change:
 
@@ -472,7 +807,7 @@ After each change:
 
 ---
 
-## 11. Safe default values
+## 14. Safe default values
 
 If tuning goes wrong, you can return to these default values:
 
@@ -490,12 +825,40 @@ const float GAIN_RX = 1.8;
 const float GAIN_RY = 1.8;
 const float GAIN_RZ = 2.0;
 
+const float MAX_SPEED_SCALE = 0.70;
+const float RESPONSE_CURVE = 1.6;
+
+const int SPEED_MODE_COUNT = 3;
+const int DEFAULT_SPEED_MODE = 1;
+const float SPEED_MODE_SCALE[SPEED_MODE_COUNT] = {
+  0.50,
+  MAX_SPEED_SCALE,
+  1.00
+};
+const float SPEED_MODE_RESPONSE_CURVE[SPEED_MODE_COUNT] = {
+  1.9,
+  RESPONSE_CURVE,
+  1.3
+};
+
+const bool DEBUG_SERIAL = false;
+const unsigned long DEBUG_SERIAL_BAUD = 115200;
+const unsigned long DEBUG_SERIAL_INTERVAL_MS = 100;
+
 const float ROTATION_PRIORITY = 0.65;
+
+const int buttonPins[3] = { 2, 3, 7 };
+const int BUTTON_COUNT = 3;
+const int MODE_SWITCH_BUTTONS[BUTTON_COUNT] = { 0, 1, 2 };
+const int MODE_SWITCH_BUTTON_COUNT = 3;
+const bool MODE_SWITCH_SUPPRESS_BUTTONS = true;
+const unsigned long MODE_SWITCH_CHORD_WINDOW_MS = 250;
+const unsigned long MODE_SWITCH_DEBOUNCE_MS = 500;
 ```
 
 ---
 
-## 12. Final note
+## 15. Final note
 
 Small hardware differences, joystick tolerances, soldering, wire routing, and printed part tolerances can affect the final feel of the controller.
 


### PR DESCRIPTION
## Summary

- add configurable slow / normal / fast speed profiles using speed scale and response curve values
- add a configurable button combo to cycle speed modes, with debounce and optional HID button suppression
- add chord-aware button handling so CAD apps do not receive partial speed-mode combos while quick single-button taps still pass through
- add optional Serial debug output for joystick values, button mask, speed mode, and final HID output
- document the new speed and debug parameters in the tuning guide
- ignore macOS `.DS_Store` files

## Testing

- `/opt/homebrew/bin/arduino-cli compile --fqbn arduino:avr:navcore3d /Users/kitek/Downloads/3d\ space\ mouse/github-fork/Firmware/Hackman3D_Orbit_Controller`
