### PR TITLE
Add the Orbit download counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Sensors](https://img.shields.io/badge/Joysticks-Hall%20Effect-00A6A6?style=flat-square)
 ![Open source](https://img.shields.io/badge/Open%20Source-Yes-39A845?style=flat-square)
 [![GitHub stars](https://img.shields.io/github/stars/HackMan3D/HackMan3D-Orbit-Controller?style=flat-square&logo=github&label=Stars)](https://github.com/HackMan3D/HackMan3D-Orbit-Controller/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/HackMan3D/HackMan3D-Orbit-Controller/total?style=flat-square&logo=github&label=Downloads)](https://github.com/HackMan3D/HackMan3D-Orbit-Controller/releases)
 
 # Hackman3D Orbit Controller
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Open source](https://img.shields.io/badge/Open%20Source-Yes-39A845?style=flat-square)
 [![GitHub stars](https://img.shields.io/github/stars/HackMan3D/HackMan3D-Orbit-Controller?style=flat-square&logo=github&label=Stars)](https://github.com/HackMan3D/HackMan3D-Orbit-Controller/stargazers)
 [![Downloads](https://img.shields.io/github/downloads/HackMan3D/HackMan3D-Orbit-Controller/total?style=flat-square&logo=github&label=Downloads)](https://github.com/HackMan3D/HackMan3D-Orbit-Controller/releases)
+[![Views](https://hits.sh/github.com/HackMan3D/HackMan3D-Orbit-Controller.svg?style=flat-square&label=Views&color=0A84FF)](https://github.com/HackMan3D/HackMan3D-Orbit-Controller)
 
 # Hackman3D Orbit Controller
 


### PR DESCRIPTION
## Summary
- add a dynamic total-download badge to the README header
- link the badge to the Orbit releases page

## Note
The counter tracks GitHub release asset downloads and will become meaningful when release files are published.

## Validation
- README diff checked with `git diff --cached --check`